### PR TITLE
Add ClojureScript support via reader conditionals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: clojure
+script: lein test-all

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,18 @@
   :url "https://github.com/arttuka/astar"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/data.priority-map "0.0.7"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/data.priority-map "0.0.7"]
+                 [tailrecursion/cljs-priority-map "1.1.0"]]
+  :plugins [[lein-cljsbuild "1.1.3"]
+            [lein-doo "0.1.6"]]
+  :aliases {"test-cljs" ["doo" "node" "test" "once"]
+            "test-all"  ["do" ["test"] ["test-cljs"]]}
+  :cljsbuild {:builds
+              {:test
+               {:source-paths ["src" "test"]
+                :compiler {:output-to "target/main.js"
+                           :output-dir "target"
+                           :main astar.test-runner
+                           :optimizations :simple
+                           :target :nodejs}}}})

--- a/src/astar/core.cljc
+++ b/src/astar/core.cljc
@@ -1,5 +1,6 @@
 (ns astar.core
-  (:require [clojure.data.priority-map :refer [priority-map-keyfn]]))
+  (:require #?(:clj  [clojure.data.priority-map :refer [priority-map-keyfn]]
+               :cljs [tailrecursion.priority-map :refer [priority-map-keyfn]])))
 
 (defn ^:private generate-route [node came-from]
   (loop [route '()

--- a/test/astar/core_test.cljc
+++ b/test/astar/core_test.cljc
@@ -1,6 +1,7 @@
 (ns astar.core-test
-  (:require [clojure.test :refer :all]
-            [astar.core :refer :all]))
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test :refer-macros [deftest is]])
+            [astar.core :refer [route]]))
 
 (def graph {:a [:b :c]
             :b [:a :d :e]

--- a/test/astar/test_runner.cljs
+++ b/test/astar/test_runner.cljs
@@ -1,0 +1,5 @@
+(ns astar.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [astar.core-test]))
+
+(doo-tests 'astar.core-test)


### PR DESCRIPTION
This PR adds ClojureScript support using reader conditionals (seee #2). I updated the Clojure version to 1.7.0 to support conditionals, and I'm testing using [doo](https://github.com/bensu/doo) and Node. Priority map support has been delegated to [cljs-priority-map](https://github.com/tailrecursion/cljs-priority-map), a direct port of clojure.data.priority-map.
